### PR TITLE
Potential fix for code scanning alert no. 3: Potentially unsafe quoting

### DIFF
--- a/internal/pipe/aur/aur.go
+++ b/internal/pipe/aur/aur.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"strconv"
 	"text/template"
 
 	"github.com/caarlos0/log"
@@ -152,7 +153,8 @@ func doRun(ctx *context.Context, aur config.AUR, cl client.ReleaseURLTemplater) 
 			folder := artifact.ExtraOr(*art, artifact.ExtraWrappedIn, ".")
 			for _, bin := range artifact.MustExtra[[]string](*art, artifact.ExtraBinaries) {
 				path := filepath.ToSlash(filepath.Clean(filepath.Join(folder, bin)))
-				pkg = fmt.Sprintf(`install -Dm755 "./%s" "${pkgdir}/usr/bin/%s"`, path, bin)
+				escapedBin := strings.Trim(strconv.Quote(bin), `"`)
+				pkg = fmt.Sprintf(`install -Dm755 "./%s" "${pkgdir}/usr/bin/%s"`, path, escapedBin)
 				break
 			}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/CosmicJesterX/goreleaser/security/code-scanning/3](https://github.com/CosmicJesterX/goreleaser/security/code-scanning/3)

To fix the problem, we need to ensure that any user-provided data embedded in the command string is properly sanitized to prevent command injection. The best way to achieve this is by escaping any special characters in the `bin` value before embedding it in the command string.

We will use the `strconv.Quote` function to escape the `bin` value. This function will add double quotes around the string and escape any special characters within it. We will then remove the surrounding double quotes to fit the single-quoted command structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
